### PR TITLE
fix(sdk): close ready channel when gRPC connect fails

### DIFF
--- a/sdk/exporter.go
+++ b/sdk/exporter.go
@@ -49,6 +49,7 @@ func (e *BatchExporter) connect() {
 	)
 	if err != nil {
 		slog.Error("failed to connect to collector", "error", err, "addr", e.collectorAddr)
+		close(e.ready) // unblock Flush so it doesn't wait 3s on every call
 		return
 	}
 	e.mu.Lock()


### PR DESCRIPTION
## Problem

When `grpc.NewClient` returns an error in `connect()`, the `ready` channel is never closed. This causes every subsequent `Flush()` call to block for 3 seconds waiting on `time.After(3 * time.Second)` before timing out and returning early. On `Shutdown()`, this also delays the final flush.

## Fix

Close the `ready` channel on connect error so `Flush()` unblocks immediately and falls through to the existing `client == nil` guard, which correctly re-enqueues the spans.

```go
if err != nil {
    slog.Error("failed to connect to collector", ...)
    close(e.ready) // unblock Flush so it does not wait 3s on every call
    return
}
```

## Impact

- No behavior change when connection succeeds
- When connection fails: `Flush()` returns immediately instead of blocking 3s, spans are re-enqueued as before
- `Shutdown()` no longer hangs when collector address is unreachable